### PR TITLE
Fix duplicate gtag scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,35 +3,16 @@
 <head>
 <link type="image/png" sizes="32x32" rel="icon" href="favicon-32.png">
   <!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-032NE3P86V"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-032NE3P86V"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
 
-  gtag('config', 'G-032NE3P86V');
-</script>
-
-  
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-N5BJGK8EZ1"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-N5BJGK8EZ1');
-</script>
-  
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-0CC016BBCT"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-0CC016BBCT');
-</script>
+    gtag('config', 'G-032NE3P86V');
+    gtag('config', 'G-N5BJGK8EZ1');
+    gtag('config', 'G-0CC016BBCT');
+  </script>
 
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
## Summary
- remove duplicate Google Analytics snippets in **index.html**
- keep a single gtag.js include with multiple config calls

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684dc485b134832ca0319885858cf474